### PR TITLE
Close option tags in datalist

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,9 +521,9 @@
                 <label for="idl">Datalist</label>
                 <input type="text" id="idl" list="example-list">
                 <datalist id="example-list">
-                  <option value="Example #1">
-                  <option value="Example #2">
-                  <option value="Example #3">
+                  <option value="Example #1" />
+                  <option value="Example #2" />
+                  <option value="Example #3" />
                 </datalist>
               </p>
             </fieldset>


### PR DESCRIPTION
While most browsers might be smart enough to figure it out, `<option>` tags can have children and need to be closed. Some apps/servers will have trouble with it otherwise (for example, this caused vitejs to crash).